### PR TITLE
feat: Adiciona viewmodels para Cliente, Contato, Documento e Endereco

### DIFF
--- a/src/CadastroClientes.App/Models/ClienteViewModel.cs
+++ b/src/CadastroClientes.App/Models/ClienteViewModel.cs
@@ -1,0 +1,41 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace CadastroClientes.App.Models;
+
+[ExcludeFromCodeCoverage]
+public class ClienteViewModel
+{
+    [Key] public Guid Id { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [StringLength(100, ErrorMessage = "O campo {0} deve ter no máximo {1} caracteres.")]
+    [Display(Name = "Nome Fantasia")]
+    [DataType(DataType.Text)]
+    public string NomeFantasia { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [StringLength(100, ErrorMessage = "O campo {0} deve ter no máximo {1} caracteres.")]
+    [Display(Name = "Razão Social")]
+    [DataType(DataType.Text)]
+    public string RazaoSocial { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [StringLength(50, ErrorMessage = "O campo {0} deve ter no máximo {1} caracteres.")]
+    [Display(Name = "CNPJ")]
+    [DataType(DataType.Text)]
+    public string Cnpj { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [DisplayFormat(DataFormatString = "{0:dd/MM/yyyy}", ApplyFormatInEditMode = true)]
+    [Display(Name = "Data de Cadastro")]
+    [DataType(DataType.Date)]
+    public DateTime DataCadastro { get; set; }
+
+    [Display(Name = "Endereço")] public EnderecoViewModel Endereco { get; set; }
+
+    [Display(Name = "Contatos")] public List<ContatoViewModel> Contatos { get; set; }
+
+    [Display(Name = "Documentos")] public List<DocumentoViewModel> Documentos { get; set; }
+}

--- a/src/CadastroClientes.App/Models/ContatoViewModel.cs
+++ b/src/CadastroClientes.App/Models/ContatoViewModel.cs
@@ -1,0 +1,55 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Diagnostics.CodeAnalysis;
+
+namespace CadastroClientes.App.Models;
+
+[ExcludeFromCodeCoverage]
+public class ContatoViewModel
+{
+    [Key] public Guid Id { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [StringLength(300, ErrorMessage = "O campo {0} deve ter no máximo {1} caracteres.")]
+    [Display(Name = "Descrição do Contato")]
+    [DataType(DataType.Text)]
+    public string DescricaoContato { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [StringLength(100, ErrorMessage = "O campo {0} deve ter no máximo {1} caracteres.")]
+    [Display(Name = "Nome do Representante")]
+    [DataType(DataType.Text)]
+    public string NomeRepresentante { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [StringLength(100, ErrorMessage = "O campo {0} deve ter no máximo {1} caracteres.")]
+    [Display(Name = "Email do Representante")]
+    [DataType(DataType.EmailAddress)]
+    public string EmailRepresentante { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [StringLength(20, ErrorMessage = "O campo {0} deve ter no máximo {1} caracteres.")]
+    [Display(Name = "Telefone do Representante")]
+    [DataType(DataType.PhoneNumber)]
+    public string TelefoneRepresentante { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [StringLength(100, ErrorMessage = "O campo {0} deve ter no máximo {1} caracteres.")]
+    [Display(Name = "Email Comercial")]
+    [DataType(DataType.EmailAddress)]
+    public string EmailComercial { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [StringLength(20, ErrorMessage = "O campo {0} deve ter no máximo {1} caracteres.")]
+    [Display(Name = "Telefone Comercial")]
+    [DataType(DataType.PhoneNumber)]
+    public string TelefoneComercial { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [StringLength(100, ErrorMessage = "O campo {0} deve ter no máximo {1} caracteres.")]
+    [Display(Name = "Cargo")]
+    [DataType(DataType.Text)]
+    public string Cargo { get; set; }
+
+    [ForeignKey("Cliente")] public Guid ClienteId { get; set; }
+}

--- a/src/CadastroClientes.App/Models/DocumentoViewModel.cs
+++ b/src/CadastroClientes.App/Models/DocumentoViewModel.cs
@@ -1,0 +1,33 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace CadastroClientes.App.Models;
+
+[ExcludeFromCodeCoverage]
+public class DocumentoViewModel
+{
+    [Key] public Guid Id { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório")]
+    [StringLength(500, ErrorMessage = "O campo {0} deve ter no máximo {1} caracteres.")]
+    [Display(Name = "Descrição")]
+    [DataType(DataType.Text)]
+    public string Descricao { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [DisplayFormat(DataFormatString = "{0:dd/MM/yyyy}", ApplyFormatInEditMode = true)]
+    [Display(Name = "Data e Hora de Criação")]
+    [DataType(DataType.DateTime)]
+    public DateTime DataHoraCriacao { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [Display(Name = "Tipo de Documento")]
+    public List<TipoDocumentoViewModel> TipoDocumentos { get; set; }
+
+    public List<SelectListItem> TipoDocumentosSelectListItem { get; set; }
+    public TipoDocumentoViewModel TipoDocumento { get; set; }
+
+    [ForeignKey("Cliente")] public Guid ClienteId { get; set; }
+}

--- a/src/CadastroClientes.App/Models/EnderecoViewModel.cs
+++ b/src/CadastroClientes.App/Models/EnderecoViewModel.cs
@@ -1,0 +1,55 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Diagnostics.CodeAnalysis;
+
+namespace CadastroClientes.App.Models;
+
+[ExcludeFromCodeCoverage]
+public class EnderecoViewModel
+{
+    [Key] public Guid Id { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [StringLength(200, ErrorMessage = "O campo {0} deve ter no máximo {1} caracteres.")]
+    [Display(Name = "Logradouro")]
+    [DataType(DataType.Text)]
+    public string Logradouro { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [StringLength(20, ErrorMessage = "O campo {0} deve ter no máximo {1} caracteres.")]
+    [Display(Name = "Número")]
+    [DataType(DataType.Text)]
+    public string Numero { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [StringLength(50, ErrorMessage = "O campo {0} deve ter no máximo {1} caracteres.")]
+    [Display(Name = "Bairro")]
+    [DataType(DataType.Text)]
+    public string Bairro { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [StringLength(50, ErrorMessage = "O campo {0} deve ter no máximo {1} caracteres.")]
+    [Display(Name = "Cidade")]
+    [DataType(DataType.Text)]
+    public string Cidade { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [StringLength(50, ErrorMessage = "O campo {0} deve ter no máximo {1} caracteres.")]
+    [Display(Name = "Estado")]
+    [DataType(DataType.Text)]
+    public string Estado { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [StringLength(50, ErrorMessage = "O campo {0} deve ter no máximo {1} caracteres.")]
+    [Display(Name = "País")]
+    [DataType(DataType.Text)]
+    public string Pais { get; set; }
+
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [StringLength(50, ErrorMessage = "O campo {0} deve ter no máximo {1} caracteres.")]
+    [Display(Name = "CEP")]
+    [DataType(DataType.Text)]
+    public string Cep { get; set; }
+
+    [ForeignKey("Cliente")] public Guid ClienteId { get; set; }
+}

--- a/src/CadastroClientes.App/Models/TipoDocumentoViewModel.cs
+++ b/src/CadastroClientes.App/Models/TipoDocumentoViewModel.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace CadastroClientes.App.Models;
+
+public enum TipoDocumentoViewModel
+{
+    [Display(Name = "Contrato")] Contrato = 1,
+
+    [Display(Name = "Certidão")] Certidao = 2,
+
+    [Display(Name = "Certificado")] Certificado = 3
+}


### PR DESCRIPTION
Foram criadas classes de modelo no namespace `CadastroClientes.App.Models` para representar as entidades `Cliente`, `Contato`, `Documento`, `Endereco` e `TipoDocumento`. Cada classe inclui propriedades com validações de dados, como chave primária, obrigatoriedade, comprimento máximo e formatação de exibição. Além disso, as classes possuem um atributo para excluir a cobertura de código nos testes. A classe `TipoDocumentoViewModel` foi implementada como um enum com três tipos de documentos: Contrato, Certidão e Certificado.