### PR TITLE
feat: Adiciona suporte a documentos no gerenciamento de clientes

### DIFF
--- a/src/CadastroClientes.App/Controllers/ClientesController.cs
+++ b/src/CadastroClientes.App/Controllers/ClientesController.cs
@@ -8,10 +8,12 @@ namespace CadastroClientes.App.Controllers
     public class ClientesController : Controller
     {
         private readonly IClienteRepository _clienteRepository;
+        private readonly IDocumentoRepository _documentoRepository;
 
-        public ClientesController(IClienteRepository clienteRepository)
+        public ClientesController(IClienteRepository clienteRepository, IDocumentoRepository documentoRepository)
         {
             _clienteRepository = clienteRepository;
+            _documentoRepository = documentoRepository;
         }
 
         public async Task<IActionResult> Index()
@@ -34,6 +36,15 @@ namespace CadastroClientes.App.Controllers
                 Cnpj = cliente.Cnpj,
                 DataCadastro = cliente.DataCadastro,
                 Contatos = cliente.Contatos.Select(contato => new ContatoViewModel(contato)).ToList(),
+                Documento = new DocumentoViewModel { ClienteId = cliente.Id },
+                Documentos = cliente.Documentos.Select(doc => new DocumentoViewModel
+                {
+                    Id = doc.Id,
+                    Descricao = doc.Descricao,
+                    NomeArquivo = doc.NomeArquivo,
+                    DataHoraCriacao = doc.DataHoraCriacao,
+                    TipoDocumento = (TipoDocumentoViewModel)doc.TipoDocumento
+                }).ToList(),
                 Endereco = new EnderecoViewModel
                 {
                     Logradouro = cliente.Endereco.Logradouro,
@@ -186,6 +197,31 @@ namespace CadastroClientes.App.Controllers
             {
                 throw new Exception("Ocorreu um erro ao excluir o cliente. Tente novamente.");
             }
+        }
+
+        [HttpPost]
+        public async Task<ActionResult> AdicionarDocumento(ClienteViewModel clienteViewModel)
+        {
+            var cliente = await _clienteRepository.ObterPorId(clienteViewModel.Documento.ClienteId) ?? null;
+
+            if (cliente == null) return NotFound();
+
+            var documento = new Documento(
+                clienteViewModel.Documento.Descricao,
+                $"{Guid.NewGuid()}-nome-do-arquivo.pdf",
+                (TipoDocumento)clienteViewModel.Documento.TipoDocumento,
+                cliente);
+
+            try
+            {
+                _documentoRepository.Adicionar(documento);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(ex?.InnerException?.Message);
+            }
+
+            return RedirectToAction(nameof(Details), new { id = clienteViewModel.Documento.ClienteId });
         }
     }
 }

--- a/src/CadastroClientes.App/Models/ClienteViewModel.cs
+++ b/src/CadastroClientes.App/Models/ClienteViewModel.cs
@@ -23,6 +23,7 @@ public class ClienteViewModel
             ? new ContatoViewModel(cliente.Contatos.FirstOrDefault())
             : null;
         Contatos = cliente.Contatos.Select(contato => new ContatoViewModel(contato)).ToList();
+        Documento = new DocumentoViewModel();
         Endereco = new EnderecoViewModel
         {
             Logradouro = cliente.Endereco.Logradouro,
@@ -67,5 +68,7 @@ public class ClienteViewModel
 
     [Display(Name = "Contatos")] public List<ContatoViewModel> Contatos { get; set; } = new List<ContatoViewModel>();
 
-    //[Display(Name = "Documentos")] public List<DocumentoViewModel> Documentos { get; set; }
+    [Display(Name = "Documentos")] public DocumentoViewModel Documento { get; set; }
+
+    public List<DocumentoViewModel> Documentos { get; set; }
 }

--- a/src/CadastroClientes.App/Models/DocumentoViewModel.cs
+++ b/src/CadastroClientes.App/Models/DocumentoViewModel.cs
@@ -16,6 +16,10 @@ public class DocumentoViewModel
     [DataType(DataType.Text)]
     public string Descricao { get; set; }
 
+    [Display(Name = "Nome do Arquivo")] public string NomeArquivo { get; set; }
+
+    public string ChaveAcessoArmazenamento { get; set; }
+
     [Required(ErrorMessage = "O campo {0} é obrigatório.")]
     [DisplayFormat(DataFormatString = "{0:dd/MM/yyyy}", ApplyFormatInEditMode = true)]
     [Display(Name = "Data e Hora de Criação")]
@@ -26,8 +30,7 @@ public class DocumentoViewModel
     [Display(Name = "Tipo de Documento")]
     public List<TipoDocumentoViewModel> TipoDocumentos { get; set; }
 
-    public List<SelectListItem> TipoDocumentosSelectListItem { get; set; }
-    public TipoDocumentoViewModel TipoDocumento { get; set; }
+    [Display(Name = "Tipo de Documento")] public TipoDocumentoViewModel TipoDocumento { get; set; }
 
     [ForeignKey("Cliente")] public Guid ClienteId { get; set; }
 }

--- a/src/CadastroClientes.App/Views/Clientes/Details.cshtml
+++ b/src/CadastroClientes.App/Views/Clientes/Details.cshtml
@@ -1,142 +1,211 @@
 ﻿@model CadastroClientes.App.Models.ClienteViewModel
-
+@using CadastroClientes.App.Models
 @{
     ViewData["Title"] = "Detalhes";
 }
 
 <h1>Detalhes</h1>
 
-<div>
-    <hr/>
-    <dl class="row">
-        <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.NomeFantasia)
-        </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.NomeFantasia)
-        </dd>
-        <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.RazaoSocial)
-        </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.RazaoSocial)
-        </dd>
-        <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.Cnpj)
-        </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Cnpj)
-        </dd>
-        <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.DataCadastro)
-        </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.DataCadastro)
-        </dd>
-    </dl>
-    <hr/>
-    <h5>Endereço</h5>
-    <dl class="row">
-        <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.Endereco.Logradouro)
-        </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Endereco.Logradouro)
-        </dd>
-        <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.Endereco.Numero)
-        </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Endereco.Numero)
-        </dd>
-        <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.Endereco.Bairro)
-        </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Endereco.Bairro)
-        </dd>
-        <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.Endereco.Cidade)
-        </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Endereco.Cidade)
-        </dd>
-        <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.Endereco.Estado)
-        </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Endereco.Estado)
-        </dd>
-        <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.Endereco.Pais)
-        </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Endereco.Pais)
-        </dd>
-        <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.Endereco.Cep)
-        </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Endereco.Cep)
-        </dd>
-    </dl>
-    <hr/>
-    <h5>Contatos</h5>
-    @{
-        if (Model.Contatos.Any())
-        {
-            @foreach (var item in Model.Contatos)
+<div class="row">
+    <div class="col-6">
+        <hr/>
+        <h5>Dados do Cliente</h5>
+        <dl class="row">
+            <dt class="col-sm-4">
+                @Html.DisplayNameFor(model => model.NomeFantasia)
+            </dt>
+            <dd class="col-sm-8">
+                @Html.DisplayFor(model => model.NomeFantasia)
+            </dd>
+            <dt class="col-sm-4">
+                @Html.DisplayNameFor(model => model.RazaoSocial)
+            </dt>
+            <dd class="col-sm-8">
+                @Html.DisplayFor(model => model.RazaoSocial)
+            </dd>
+            <dt class="col-sm-4">
+                @Html.DisplayNameFor(model => model.Cnpj)
+            </dt>
+            <dd class="col-sm-8">
+                @Html.DisplayFor(model => model.Cnpj)
+            </dd>
+            <dt class="col-sm-4">
+                @Html.DisplayNameFor(model => model.DataCadastro)
+            </dt>
+            <dd class="col-sm-8">
+                @Html.DisplayFor(model => model.DataCadastro)
+            </dd>
+        </dl>
+        <hr/>
+        <h5>Endereço</h5>
+        <dl class="row">
+            <dt class="col-sm-4">
+                @Html.DisplayNameFor(model => model.Endereco.Logradouro)
+            </dt>
+            <dd class="col-sm-8">
+                @Html.DisplayFor(model => model.Endereco.Logradouro)
+            </dd>
+            <dt class="col-sm-4">
+                @Html.DisplayNameFor(model => model.Endereco.Numero)
+            </dt>
+            <dd class="col-sm-8">
+                @Html.DisplayFor(model => model.Endereco.Numero)
+            </dd>
+            <dt class="col-sm-4">
+                @Html.DisplayNameFor(model => model.Endereco.Bairro)
+            </dt>
+            <dd class="col-sm-8">
+                @Html.DisplayFor(model => model.Endereco.Bairro)
+            </dd>
+            <dt class="col-sm-4">
+                @Html.DisplayNameFor(model => model.Endereco.Cidade)
+            </dt>
+            <dd class="col-sm-8">
+                @Html.DisplayFor(model => model.Endereco.Cidade)
+            </dd>
+            <dt class="col-sm-4">
+                @Html.DisplayNameFor(model => model.Endereco.Estado)
+            </dt>
+            <dd class="col-sm-8">
+                @Html.DisplayFor(model => model.Endereco.Estado)
+            </dd>
+            <dt class="col-sm-4">
+                @Html.DisplayNameFor(model => model.Endereco.Pais)
+            </dt>
+            <dd class="col-sm-8">
+                @Html.DisplayFor(model => model.Endereco.Pais)
+            </dd>
+            <dt class="col-sm-4">
+                @Html.DisplayNameFor(model => model.Endereco.Cep)
+            </dt>
+            <dd class="col-sm-8">
+                @Html.DisplayFor(model => model.Endereco.Cep)
+            </dd>
+        </dl>
+        <hr/>
+        <h5>Contatos</h5>
+        @{
+            if (Model.Contatos.Any())
             {
-                <div class="card shadow-sm" style="width: 34rem;">
-                    <div class="card-body">
-                        <h5 class="card-title">
-                            @Html.DisplayFor(model => item.NomeRepresentante)
-                        </h5>
-                        <h6 class="card-subtitle mb-2 text-body-secondary text-black-50">
-                            @Html.DisplayFor(model => item.DescricaoContato)
-                        </h6>
-                        <hr/>
-                        <dl class="row">
-                            <dt class="col-sm-6">
-                                @Html.DisplayNameFor(model => item.DescricaoContato)
-                            </dt>
-                            <dd class="col-sm-6">
+                foreach (var item in Model.Contatos)
+                {
+                    <div class="card shadow-sm">
+                        <div class="card-body">
+                            <h5 class="card-title">
+                                @Html.DisplayFor(model => item.NomeRepresentante)
+                            </h5>
+                            <h6 class="card-subtitle mb-2 text-body-secondary text-black-50">
                                 @Html.DisplayFor(model => item.DescricaoContato)
-                            </dd>
-                            <dt class="col-sm-6">
-                                @Html.DisplayNameFor(model => item.EmailRepresentante)
-                            </dt>
-                            <dd class="col-sm-6">
-                                @Html.DisplayFor(model => item.EmailRepresentante)
-                            </dd>
-                            <dt class="col-sm-6">
-                                @Html.DisplayNameFor(model => item.TelefoneRepresentante)
-                            </dt>
-                            <dd class="col-sm-6">
-                                @Html.DisplayFor(model => item.TelefoneRepresentante)
-                            </dd>
-                            <dt class="col-sm-6">
-                                @Html.DisplayNameFor(model => item.EmailComercial)
-                            </dt>
-                            <dd class="col-sm-6">
-                                @Html.DisplayFor(model => item.EmailComercial)
-                            </dd>
-                            <dt class="col-sm-6">
-                                @Html.DisplayNameFor(model => item.TelefoneComercial)
-                            </dt>
-                            <dd class="col-sm-6">
-                                @Html.DisplayFor(model => item.TelefoneComercial)
-                            </dd>
-                        </dl>
+                            </h6>
+                            <hr/>
+                            <dl class="row">
+                                <dt class="col-sm-6">
+                                    @Html.DisplayNameFor(model => item.DescricaoContato)
+                                </dt>
+                                <dd class="col-sm-6">
+                                    @Html.DisplayFor(model => item.DescricaoContato)
+                                </dd>
+                                <dt class="col-sm-6">
+                                    @Html.DisplayNameFor(model => item.EmailRepresentante)
+                                </dt>
+                                <dd class="col-sm-6">
+                                    @Html.DisplayFor(model => item.EmailRepresentante)
+                                </dd>
+                                <dt class="col-sm-6">
+                                    @Html.DisplayNameFor(model => item.TelefoneRepresentante)
+                                </dt>
+                                <dd class="col-sm-6">
+                                    @Html.DisplayFor(model => item.TelefoneRepresentante)
+                                </dd>
+                                <dt class="col-sm-6">
+                                    @Html.DisplayNameFor(model => item.EmailComercial)
+                                </dt>
+                                <dd class="col-sm-6">
+                                    @Html.DisplayFor(model => item.EmailComercial)
+                                </dd>
+                                <dt class="col-sm-6">
+                                    @Html.DisplayNameFor(model => item.TelefoneComercial)
+                                </dt>
+                                <dd class="col-sm-6">
+                                    @Html.DisplayFor(model => item.TelefoneComercial)
+                                </dd>
+                            </dl>
+                        </div>
                     </div>
-                </div>
+                }
+            }
+            else
+            {
+                <h6 class="text-black-50">Não há contatos cadastrados</h6>
             }
         }
-        else
-        {
-            <h6 class="text-black-50">Não há contatos cadastrados</h6>
+    </div>
+    <div class="col-6">
+        <hr/>
+        <h5>Documentos</h5>
+        <form asp-action="AdicionarDocumento">
+            <div class="form-group">
+                <label asp-for="Documento.Descricao" class="control-label"></label>
+                <textarea asp-for="Documento.Descricao" class="form-control"></textarea>
+                <span asp-validation-for="Documento.Descricao" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Documento.TipoDocumento" class="control-label"></label>
+                <select asp-for="Documento.TipoDocumento" class="form-control" data-control="select2"
+                        data-hide-search="true" asp-items="Html.GetEnumSelectList<TipoDocumentoViewModel>()"
+                        style="cursor: pointer;">
+                    <option value="" selected disabled>Selecionar</option>
+                </select>
+                <span asp-validation-for="Documento.TipoDocumento" class="text-danger"></span>
+            </div>
+            <input type="hidden" asp-for="Documento.ClienteId"/>
+            <br/>
+            <div class="form-group">
+                <input type="submit" value="Importar documento" class="btn btn-primary"/>
+            </div>
+        </form>
+        <br/>
+        @{
+            if (Model.Documentos.Any())
+            {
+                foreach (var item in Model.Documentos)
+                {
+                    <div class="card shadow-sm">
+                        <div class="card-body">
+                            <h5 class="card-title">
+                                @Html.DisplayFor(model => item.NomeArquivo)
+                            </h5>
+                            <dl class="row">
+                                <dt class="col-sm-6">
+                                    @Html.DisplayNameFor(model => item.Descricao)
+                                </dt>
+                                <dd class="col-sm-6">
+                                    @Html.DisplayFor(model => item.Descricao)
+                                </dd>
+                                <dt class="col-sm-6">
+                                    @Html.DisplayNameFor(model => item.TipoDocumento)
+                                </dt>
+                                <dd class="col-sm-6">
+                                    @Html.DisplayFor(model => item.TipoDocumento)
+                                </dd>
+                                <dt class="col-sm-6">
+                                    @Html.DisplayNameFor(model => item.DataHoraCriacao)
+                                </dt>
+                                <dd class="col-sm-6">
+                                    @Html.DisplayFor(model => item.DataHoraCriacao)
+                                </dd>
+                            </dl>
+                        </div>
+                    </div>
+                    <br/>
+                }
+            }
+            else
+            {
+                <h6 class="text-black-50">Não há documentos cadastrados</h6>
+            }
         }
-    }
+    </div>
 </div>
 <br/>
 <div>

--- a/src/CadastroClientes.Business/Models/Documento.cs
+++ b/src/CadastroClientes.Business/Models/Documento.cs
@@ -12,17 +12,21 @@ public class Documento : Entity
 
     public Documento(
         string descricao,
+        string nomeArquivo,
         TipoDocumento tipoDocumento,
         Cliente cliente)
     {
         Descricao = descricao;
+        NomeArquivo = nomeArquivo;
+        ChaveAcessoArmazenamento = string.Empty;
         DataHoraCriacao = DateTime.Now;
         TipoDocumento = tipoDocumento;
-        Cliente = cliente;
         ClienteId = cliente.Id;
     }
 
     public string Descricao { get; private set; }
+    public string NomeArquivo { get; private set; }
+    public string ChaveAcessoArmazenamento { get; private set; }
     public DateTime DataHoraCriacao { get; private set; }
     public TipoDocumento TipoDocumento { get; private set; }
     public Cliente Cliente { get; private set; }

--- a/src/CadastroClientes.Data/Mappings/DocumentoMapping.cs
+++ b/src/CadastroClientes.Data/Mappings/DocumentoMapping.cs
@@ -18,6 +18,16 @@ public class DocumentoMapping : IEntityTypeConfiguration<Documento>
             .HasColumnType("varchar(500)");
 
         builder
+            .Property(d => d.NomeArquivo)
+            .IsRequired()
+            .HasColumnType("varchar(200)");
+
+        builder
+            .Property(d => d.ChaveAcessoArmazenamento)
+            .IsRequired()
+            .HasColumnType("varchar(200)");
+
+        builder
             .Property(d => d.DataHoraCriacao)
             .IsRequired();
 

--- a/src/CadastroClientes.Data/Migrations/20250902210431_update-table-documentos.Designer.cs
+++ b/src/CadastroClientes.Data/Migrations/20250902210431_update-table-documentos.Designer.cs
@@ -4,6 +4,7 @@ using CadastroClientes.Data.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CadastroClientes.Data.Migrations
 {
     [DbContext(typeof(CadastroClientesDbContext))]
-    partial class CadastroClientesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250902210431_update-table-documentos")]
+    partial class updatetabledocumentos
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/CadastroClientes.Data/Migrations/20250902210431_update-table-documentos.cs
+++ b/src/CadastroClientes.Data/Migrations/20250902210431_update-table-documentos.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CadastroClientes.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class updatetabledocumentos : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ChaveAcessoArmazenamento",
+                table: "Documentos",
+                type: "varchar(200)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "NomeArquivo",
+                table: "Documentos",
+                type: "varchar(200)",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ChaveAcessoArmazenamento",
+                table: "Documentos");
+
+            migrationBuilder.DropColumn(
+                name: "NomeArquivo",
+                table: "Documentos");
+        }
+    }
+}


### PR DESCRIPTION
Implementa repositório de documentos e método para adicionar documentos a clientes no `ClientesController`. Atualiza `ClienteViewModel` para incluir um campo para documento específico e mantém a lista de documentos. Modifica `DocumentoViewModel` para adicionar propriedades `NomeArquivo` e `ChaveAcessoArmazenamento`. Atualiza mapeamento e snapshot do banco de dados para refletir as novas colunas. Cria migrações para adicionar as colunas ao banco de dados.