### PR TITLE
feat: Aprimora upload de documentos e ajusta interface

### DIFF
--- a/src/CadastroClientes.App/Controllers/ClientesController.cs
+++ b/src/CadastroClientes.App/Controllers/ClientesController.cs
@@ -213,7 +213,7 @@ namespace CadastroClientes.App.Controllers
 
             var documento = new Documento(
                 documentoViewModel.Descricao,
-                $"{Guid.NewGuid()}-nome-do-arquivo.pdf",
+                documentoViewModel.Arquivo.FileName,
                 (TipoDocumento)documentoViewModel.TipoDocumento,
                 cliente);
 

--- a/src/CadastroClientes.App/Models/DocumentoViewModel.cs
+++ b/src/CadastroClientes.App/Models/DocumentoViewModel.cs
@@ -26,6 +26,11 @@ public class DocumentoViewModel
     [DataType(DataType.DateTime)]
     public DateTime DataHoraCriacao { get; set; }
 
+    [Required(ErrorMessage = "O campo {0} é obrigatório.")]
+    [Display(Name = "Arquivo")]
+    [DataType(DataType.Upload)]
+    public IFormFile Arquivo { get; set; }
+
     [Display(Name = "Tipo de Documento")] public TipoDocumentoViewModel TipoDocumento { get; set; }
 
     [ForeignKey("Cliente")] public Guid ClienteId { get; set; }

--- a/src/CadastroClientes.App/Views/Clientes/Delete.cshtml
+++ b/src/CadastroClientes.App/Views/Clientes/Delete.cshtml
@@ -6,9 +6,10 @@
 
 <h1>Deletar</h1>
 
-<h3>Tem certeza de que deseja excluir isto?</h3>
+<h3 class="text-danger">Tem certeza de que deseja excluir isto?</h3>
 <div>
     <hr/>
+    <h5>Dados do Cliente</h5>
     <dl class="row">
         <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.NomeFantasia)
@@ -94,7 +95,7 @@
                             @Html.DisplayFor(model => item.NomeRepresentante)
                         </h5>
                         <h6 class="card-subtitle mb-2 text-body-secondary text-black-50">
-                            @Html.DisplayFor(model => item.DescricaoContato)
+                            @Html.DisplayFor(model => item.Cargo)
                         </h6>
                         <hr/>
                         <dl class="row">

--- a/src/CadastroClientes.App/Views/Clientes/Details.cshtml
+++ b/src/CadastroClientes.App/Views/Clientes/Details.cshtml
@@ -144,7 +144,7 @@
     <div class="col-6">
         <hr/>
         <h5>Documentos</h5>
-        <form asp-action="AdicionarDocumento">
+        <form asp-action="AdicionarDocumento" enctype="multipart/form-data">
             <div class="form-group">
                 <label asp-for="@documento.Descricao" class="control-label"></label>
                 <textarea name="descricao" asp-for="@documento.Descricao" class="form-control"></textarea>
@@ -159,6 +159,11 @@
                     <option value="" selected disabled>Selecionar</option>
                 </select>
                 <span asp-validation-for="@documento.TipoDocumento" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="@documento.Arquivo" for="formFile" class="control-label"></label>
+                <input asp-for="@documento.Arquivo" name="Arquivo" type="file" class="form-control" id="formFile">
+                <span asp-validation-for="@documento.Arquivo" class="text-danger"></span>
             </div>
             <input type="hidden" name="clienteId" asp-for="@Model.Id"/>
             <br/>


### PR DESCRIPTION
Modifica o nome do arquivo gerado para documentos, utilizando o nome enviado pelo usuário. Adiciona campo obrigatório para upload de arquivos no `DocumentoViewModel`. Estiliza a mensagem de confirmação de exclusão no `Delete.cshtml` e ajusta a exibição de campos. Atualiza o formulário em `Details.cshtml` para suportar upload de arquivos.